### PR TITLE
Regex patterns to ignore PRs

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -63,5 +63,6 @@ jobs:
           dependency-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dependency_type || 'direct:production' }}
           merge-method: 'squash'
           add-label: ${{ github.event_name == 'workflow_dispatch' && 'manual-approval' || 'dependabot-approved' }}
+          ignore-regex: '.*security.*,.*major.*'
           pr-number: ${{ github.event_name == 'workflow_dispatch' && steps.pr_info.outputs.pr_number || '' }}
           pr-url: ${{ github.event_name == 'workflow_dispatch' && steps.pr_info.outputs.pr_url || '' }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -63,6 +63,6 @@ jobs:
           dependency-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dependency_type || 'direct:production' }}
           merge-method: 'squash'
           add-label: ${{ github.event_name == 'workflow_dispatch' && 'manual-approval' || 'dependabot-approved' }}
-          ignore-regex: '.*security.*,.*major.*'
+          ignore-regex-pr-title: '.*security.*,.*major.*'
           pr-number: ${{ github.event_name == 'workflow_dispatch' && steps.pr_info.outputs.pr_number || '' }}
           pr-url: ${{ github.event_name == 'workflow_dispatch' && steps.pr_info.outputs.pr_url || '' }}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
 | `merge-method` | Merge method | No | `squash` |
 | `auto-merge` | Enable auto-merge | No | `false` |
 | `add-label` | Label for approved PRs | No | `dependabot-approved` |
-| `ignore-regex` | Regex patterns to ignore PRs (comma-separated) | No | |
+| `ignore-regex-pr-title` | Regex patterns to ignore PRs (comma-separated) | No | |
 | `pr-number` | PR number (for manual dispatch workflows) | No | |
 | `pr-url` | PR URL (for manual dispatch workflows) | No | |
 
@@ -87,9 +87,9 @@ jobs:
 You can specify one or more regex patterns (comma-separated) to skip auto-approval for certain PRs. If any pattern matches the PR title, the PR will be ignored.
 
 Examples:
-- `ignore-regex: '.*security.*,.*major.*'` - Skip PRs with "security" or "major" in the title
-- `ignore-regex: '^Bump.*from.*to.*'` - Skip PRs with specific version bump patterns
-- `ignore-regex: '.*breaking.*,.*deprecated.*'` - Skip PRs with breaking changes or deprecations
+- `ignore-regex-pr-title: '.*security.*,.*major.*'` - Skip PRs with "security" or "major" in the title
+- `ignore-regex-pr-title: '^Bump.*from.*to.*'` - Skip PRs with specific version bump patterns
+- `ignore-regex-pr-title: '.*breaking.*,.*deprecated.*'` - Skip PRs with breaking changes or deprecations
 
 ## Requirements
 
@@ -233,7 +233,7 @@ jobs:
       - uses: ad/dependabot-auto-approve@v1
         with:
           dependency-type: 'direct:production'
-          ignore-regex: '.*security.*,.*major.*'
+          ignore-regex-pr-title: '.*security.*,.*major.*'
           merge-method: 'squash'
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ jobs:
 | `merge-method` | Merge method | No | `squash` |
 | `auto-merge` | Enable auto-merge | No | `false` |
 | `add-label` | Label for approved PRs | No | `dependabot-approved` |
+| `ignore-regex` | Regex patterns to ignore PRs (comma-separated) | No | |
 | `pr-number` | PR number (for manual dispatch workflows) | No | |
 | `pr-url` | PR URL (for manual dispatch workflows) | No | |
 
@@ -80,6 +81,15 @@ jobs:
 - `squash` - squash commits into one
 - `merge` - regular merge
 - `rebase` - rebase and merge
+
+### Ignore regex patterns
+
+You can specify one or more regex patterns (comma-separated) to skip auto-approval for certain PRs. If any pattern matches the PR title, the PR will be ignored.
+
+Examples:
+- `ignore-regex: '.*security.*,.*major.*'` - Skip PRs with "security" or "major" in the title
+- `ignore-regex: '^Bump.*from.*to.*'` - Skip PRs with specific version bump patterns
+- `ignore-regex: '.*breaking.*,.*deprecated.*'` - Skip PRs with breaking changes or deprecations
 
 ## Requirements
 
@@ -203,6 +213,28 @@ jobs:
           dependency-type: 'all'
           auto-merge: 'true'
           add-label: 'auto-merged'
+```
+
+### Skip security and major updates
+
+```yaml
+name: Dependabot Auto Manage
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'app/dependabot'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'direct:production'
+          ignore-regex: '.*security.*,.*major.*'
+          merge-method: 'squash'
 ```
 
 ### Manual trigger for specific PRs

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'Label to add to approved PRs'
     required: false
     default: 'dependabot-approved'
-  ignore-regex:
+  ignore-regex-pr-title:
     description: 'Regex patterns to ignore PRs (comma-separated). If any pattern matches PR title, PR will be skipped.'
     required: false
   pr-number:
@@ -105,12 +105,12 @@ runs:
 
     - name: Check ignore regex patterns
       id: check_ignore_regex
-      if: steps.check_dependency.outputs.should_process == 'true' && inputs.ignore-regex != ''
+      if: steps.check_dependency.outputs.should_process == 'true' && inputs.ignore-regex-pr-title != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}
         PR_TITLE_EVENT: ${{ github.event.pull_request.title }}
-        IGNORE_REGEX: ${{ inputs.ignore-regex }}
+        IGNORE_REGEX: ${{ inputs.ignore-regex-pr-title }}
       run: |
         # Get PR title (use env var for pull_request events to handle special chars)
         if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -148,7 +148,7 @@ runs:
       shell: bash
       run: |
         # If ignore regex step didn't run, use the original should_process value
-        if [ "${{ inputs.ignore-regex }}" = "" ]; then
+        if [ "${{ inputs.ignore-regex-pr-title }}" = "" ]; then
           echo "should_process=${{ steps.check_dependency.outputs.should_process }}" >> $GITHUB_OUTPUT
         else
           echo "should_process=${{ steps.check_ignore_regex.outputs.should_process }}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: 'Label to add to approved PRs'
     required: false
     default: 'dependabot-approved'
+  ignore-regex:
+    description: 'Regex patterns to ignore PRs (comma-separated). If any pattern matches PR title, PR will be skipped.'
+    required: false
   pr-number:
     description: 'PR number (for manual dispatch workflows)'
     required: false
@@ -100,8 +103,59 @@ runs:
           echo "⏭️ Skipping: dependency type $DEPENDENCY_TYPE doesn't match target $TARGET_TYPE"
         fi
 
+    - name: Check ignore regex patterns
+      id: check_ignore_regex
+      if: steps.check_dependency.outputs.should_process == 'true' && inputs.ignore-regex != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        PR_TITLE_EVENT: ${{ github.event.pull_request.title }}
+        IGNORE_REGEX: ${{ inputs.ignore-regex }}
+      run: |
+        # Get PR title (use env var for pull_request events to handle special chars)
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          PR_TITLE="$PR_TITLE_EVENT"
+        else
+          PR_TITLE=$(gh pr view "${{ steps.check_dependabot.outputs.pr_number }}" --repo "${{ github.repository }}" --json title --jq '.title')
+        fi
+        
+        echo "PR Title: $PR_TITLE"
+        
+        # Check if any regex pattern matches
+        if [ -n "$IGNORE_REGEX" ]; then
+          IFS=',' read -ra PATTERNS <<< "$IGNORE_REGEX"
+          for pattern in "${PATTERNS[@]}"; do
+            # Trim whitespace
+            pattern=$(echo "$pattern" | xargs)
+            if [ -n "$pattern" ]; then
+              echo "Checking pattern: '$pattern'"
+              if echo "$PR_TITLE" | grep -qE "$pattern"; then
+                echo "❌ PR title matches ignore pattern: '$pattern'"
+                echo "should_process=false" >> $GITHUB_OUTPUT
+                echo "⏭️ Skipping PR due to ignore pattern match"
+                exit 0
+              fi
+            fi
+          done
+        fi
+        
+        echo "✅ No ignore patterns matched"
+        echo "should_process=true" >> $GITHUB_OUTPUT
+
+    - name: Set final processing flag
+      id: final_processing
+      if: steps.check_dependency.outputs.should_process == 'true'
+      shell: bash
+      run: |
+        # If ignore regex step didn't run, use the original should_process value
+        if [ "${{ inputs.ignore-regex }}" = "" ]; then
+          echo "should_process=${{ steps.check_dependency.outputs.should_process }}" >> $GITHUB_OUTPUT
+        else
+          echo "should_process=${{ steps.check_ignore_regex.outputs.should_process }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Create label if it doesn't exist
-      if: steps.check_dependency.outputs.should_process == 'true' && inputs.add-label != ''
+      if: steps.final_processing.outputs.should_process == 'true' && inputs.add-label != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}
@@ -120,7 +174,7 @@ runs:
         fi
 
     - name: Add label to PR
-      if: steps.check_dependency.outputs.should_process == 'true' && inputs.add-label != ''
+      if: steps.final_processing.outputs.should_process == 'true' && inputs.add-label != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}
@@ -129,7 +183,7 @@ runs:
         gh pr edit "${{ steps.check_dependabot.outputs.pr_url }}" --add-label "${{ inputs.add-label }}"
 
     - name: Approve PR
-      if: steps.check_dependency.outputs.should_process == 'true'
+      if: steps.final_processing.outputs.should_process == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}
@@ -157,7 +211,7 @@ runs:
         fi
 
     - name: Merge PR
-      if: steps.check_dependency.outputs.should_process == 'true'
+      if: steps.final_processing.outputs.should_process == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || github.token }}


### PR DESCRIPTION
Sometimes there are some dependencies that we don't want to auto-merge. This adds to the toolbox of rules to decide when to actually auto-merge/approve dependabot PRs.